### PR TITLE
First version of the clipboard memory NVDA plugin

### DIFF
--- a/scratchpad/globalPlugins/memory.py
+++ b/scratchpad/globalPlugins/memory.py
@@ -5,16 +5,20 @@ import ui
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
     memory = {}
 
-    def script_registerToMemory(self, gesture):
+    def script_saveToMemory(self, gesture):
         """When pressed, this key saves the text copied to the clipboard to this position on the NVDA memory."""
-        clipboardContent = api.getClipData()
+        try:
+            clipboardContent = api.getClipData()
+        except OSError:
+            ui.message("Clipboard is empty")
+            return
         keyCode = gesture.vkCode # Get which number the user pressed.
         # The number will be in the range 48 to 57 inclusive, and we will use it to hash the data in the dictionary.
         if isinstance(clipboardContent, str):
             self.memory[keyCode] = clipboardContent
             ui.message("Saved")
 
-    def script_speakMemory(self, gesture):
+    def script_speakAndCopyMemory(self, gesture):
         """When pressed, this key speaks and copies the text saved at this position of the NVDA memory to the clipboard."""
         keyCode = gesture.vkCode
         try:
@@ -29,5 +33,5 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
     # Maps all 10 numeric keyboard keys to the apropriate gesture.
     # It was done this way to avoid code repetition and to facilitate adding more commands in the future.
     for keyboardKey in range(11):
-            __gestures[f"kb:NVDA+CONTROL+{keyboardKey}"] = "registerToMemory"
-            __gestures[f"kb:NVDA+CONTROL+SHIFT+{keyboardKey}"] = "speakMemory"
+            __gestures[f"kb:NVDA+CONTROL+{keyboardKey}"] = "saveToMemory"
+            __gestures[f"kb:NVDA+CONTROL+SHIFT+{keyboardKey}"] = "speakAndCopyMemory"

--- a/scratchpad/globalPlugins/memory.py
+++ b/scratchpad/globalPlugins/memory.py
@@ -1,5 +1,6 @@
 import api
 import globalPluginHandler
+import keyboardHandler
 import ui
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
@@ -25,6 +26,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             data = self.memory[keyCode]
             api.copyToClip(data)
             ui.message(f"Copied {data}")
+            # Paste the selected text
+            keyboardHandler.KeyboardInputGesture.fromName("CONTROL+V").send()
         except KeyError:
             ui.message("No data at this position")
 

--- a/scratchpad/globalPlugins/memory.py
+++ b/scratchpad/globalPlugins/memory.py
@@ -1,0 +1,33 @@
+import api
+import globalPluginHandler
+import ui
+
+class GlobalPlugin(globalPluginHandler.GlobalPlugin):
+    memory = {}
+
+    def script_registerToMemory(self, gesture):
+        """When pressed, this key saves the text copied to the clipboard to this position on the NVDA memory."""
+        clipboardContent = api.getClipData()
+        keyCode = gesture.vkCode # Get which number the user pressed.
+        # The number will be in the range 48 to 57 inclusive, and we will use it to hash the data in the dictionary.
+        if isinstance(clipboardContent, str):
+            self.memory[keyCode] = clipboardContent
+            ui.message("Saved")
+
+    def script_speakMemory(self, gesture):
+        """When pressed, this key speaks and copies the text saved at this position of the NVDA memory to the clipboard."""
+        keyCode = gesture.vkCode
+        try:
+            data = self.memory[keyCode]
+            api.copyToClip(data)
+            ui.message(f"Copied {data}")
+        except KeyError:
+            ui.message("No data at this position")
+
+    __gestures = {}
+
+    # Maps all 10 numeric keyboard keys to the apropriate gesture.
+    # It was done this way to avoid code repetition and to facilitate adding more commands in the future.
+    for keyboardKey in range(11):
+            __gestures[f"kb:NVDA+CONTROL+{keyboardKey}"] = "registerToMemory"
+            __gestures[f"kb:NVDA+CONTROL+SHIFT+{keyboardKey}"] = "speakMemory"


### PR DESCRIPTION
This plugin provides a way to save and restore clipboard contents.

Keys:
NVDA+CONTROL+numeric keys: saves the text currently on the clipboard to that memory slot.
NVDA+CONTROL+SHIFT+numeric keys: restores the text on that memory slot to the clipboard and speaks it.