### PR TITLE
Feat: Say first, copy if sure

### DIFF
--- a/scratchpad/globalPlugins/memory.py
+++ b/scratchpad/globalPlugins/memory.py
@@ -2,6 +2,7 @@ import api
 import globalPluginHandler
 import keyboardHandler
 import ui
+from scriptHandler import getLastScriptRepeatCount
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
     memory = {}
@@ -24,10 +25,13 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         keyCode = gesture.vkCode
         try:
             data = self.memory[keyCode]
-            api.copyToClip(data)
-            ui.message(f"Copied {data}")
-            # Paste the selected text
-            keyboardHandler.KeyboardInputGesture.fromName("CONTROL+V").send()
+            if getLastScriptRepeatCount() == 0:
+                ui.message(data)
+            elif getLastScriptRepeatCount() >= 1:
+                api.copyToClip(data)
+                ui.message(f"Copied {data}")
+                # Paste the selected text
+                keyboardHandler.KeyboardInputGesture.fromName("CONTROL+V").send()
         except KeyError:
             ui.message("No data at this position")
 


### PR DESCRIPTION
The script key "NVDA+ctrl+shift+[0-9]" directly pastes the memory content.
This behaviour can be anoying if the user presses the wrong number and accidentally pastes content that he don't want to be pasted.

So I decided to open this PR:
* Pressing the key to paste once, NVDA will just speak the content of this memory region.
* Pressing the key two or more times NVDA will paste the content.