### PR TITLE
Fix (issue-4): An initial way to get selected text from web pages and save it to memory

### DIFF
--- a/addon/globalPlugins/snippetsForNVDA/__init__.py
+++ b/addon/globalPlugins/snippetsForNVDA/__init__.py
@@ -12,8 +12,12 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
     def script_saveToMemory(self, gesture):
         """When pressed, this key saves the selected text to this position on the NVDA memory."""
         focus = api.getFocusObject()
+        textInfo = None
         if focus.windowClassName in ["AkelEditW"] or focus.role in [controlTypes.ROLE_EDITABLETEXT]:
             textInfo = focus.makeTextInfo(textInfos.POSITION_SELECTION)
+        elif focus.treeInterceptor is not None:
+            textInfo = focus.treeInterceptor.makeTextInfo(textInfos.POSITION_SELECTION)
+        if textInfo is not None:
             text = textInfo.text
             if len(text) > 0:
                 keyCode = gesture.vkCode # Get which number the user pressed.


### PR DESCRIPTION
With some explorations I discovered that is possible to **makeTextInfo** fom a **treeInterceptor**.

In this initiial implementation I just verify if the focused object is a editable or if the treeInterceptor is not None.
With this information I can make the textInfo.

The first bug with this implementation is 
that the HTML content is not correctly formatted when pasted to aa text editor, for example.