### PR TITLE
Restore the clipboard when pasting a snippet

### DIFF
--- a/addon/globalPlugins/snippetsForNVDA/__init__.py
+++ b/addon/globalPlugins/snippetsForNVDA/__init__.py
@@ -54,12 +54,21 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
                 ui.message(data)
                 self.lastPressedKey = keyCode
             elif getLastScriptRepeatCount() == 1 and self.isLastPressedKey(keyCode):
+                try:
+                    oldText = api.getClipData()
+                except OSError:
+                    oldText = None
+
                 api.copyToClip(data)
+
                 # Translators: The message displayed when the user pasted this memory slot to an edit field.
                 ui.message(_("Pasted {data}").format(data=data))
                 self.lastPressedKey = 0
                 # Paste the selected text
                 keyboardHandler.KeyboardInputGesture.fromName("CONTROL+V").send()
+
+                if oldText is not None:
+                    api.copyToClip(oldText)
             else:
                 self.lastPressedKey = 0
                 ui.message(data)


### PR DESCRIPTION
This pull request addresses the case when the user pastes an snippet, the clipboard is overwritten. It does this by saving the clipboard content, pasting the snippet and then copying the old content again.